### PR TITLE
Dockerfile updates for archived debian jessie repo

### DIFF
--- a/x11docker/Dockerfile
+++ b/x11docker/Dockerfile
@@ -1,7 +1,9 @@
 FROM debian:jessie-slim
 
-RUN apt-get update && \
-    apt-get install -y banshee && \
+RUN echo "deb http://archive.debian.org/debian jessie main" > /etc/apt/sources.list && \
+    echo "deb http://archive.debian.org/debian-security jessie/updates main" >> /etc/apt/sources.list && \
+    apt-get update && \
+    apt-get install --force-yes -y banshee && \
     apt-get clean && \
     apt-get autoremove && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Required for apt install to work.